### PR TITLE
Toggle switch off Re-Captcha on AMP pages

### DIFF
--- a/includes/protection/spam-master-admin-other-protection-table-integrations.php
+++ b/includes/protection/spam-master-admin-other-protection-table-integrations.php
@@ -56,6 +56,14 @@ if(is_multisite()){
 	else{
 	update_blog_option($blog_id, 'spam_master_recaptcha_preview', 'false' );
 	}
+	/* Code added by Oliver Maor */
+	if (isset($_POST['spam_master_recaptcha_ampoff'])){
+	update_blog_option($blog_id, 'spam_master_recaptcha_ampoff', $_POST['spam_master_recaptcha_ampoff'] );
+	}
+	else{
+	update_blog_option($blog_id, 'spam_master_recaptcha_ampoff', 'true' );
+	}
+	/*End code added by Oliver Maor */
 	if (isset($_POST['spam_master_honeypot_timetrap'])){
 	update_blog_option($blog_id, 'spam_master_honeypot_timetrap', $_POST['spam_master_honeypot_timetrap'] );
 	}
@@ -130,6 +138,14 @@ else{
 	else{
 	update_option('spam_master_recaptcha_preview', 'false' );
 	}
+	/* Code added by Oliver Maor */
+	if (isset($_POST['spam_master_recaptcha_ampoff'])){
+	update_option('spam_master_recaptcha_ampoff', $_POST['spam_master_recaptcha_ampoff'] );
+	}
+	else{
+	update_option('spam_master_recaptcha_ampoff', 'true' );
+	}
+	/*End code added by Oliver Maor */
 	if (isset($_POST['spam_master_honeypot_timetrap'])){
 	update_option('spam_master_honeypot_timetrap', $_POST['spam_master_honeypot_timetrap'] );
 	}
@@ -291,6 +307,9 @@ $spam_master_integrations_woocommerce = get_option('spam_master_integrations_woo
 				<p>Activating Re-Captcha adds a captcha code field to the Login Page, Registration page or to all Comments of your <b>Wordpress</b>.</p>
 				<p>Activating re-captcha will automatically eliminate all "bots" or "robots" fake registrations. <b>Make sure you have no other plugins installed that use captcha's or re-captcha</b></p>
 				<p>Re-Captcha is freely provided by google and requires a google api key that you can get in seconds. Get your free google <a href="https://www.google.com/recaptcha/intro/index.html" title="re-captcha" target="_blank">re-captcha key</a>.</p>
+				<!-- Code added by Oliver Maor-->
+				<p>Re-Captcha works on Accelerated Mobile Pages (AMP), but does not conform to the <a href="https://www.ampproject.org/docs/reference/components" target="_blank">strict AMP standard definitions</a>.<br />It is therefore recommended to switch it off for AMP pages.</p>
+				<!-- End code added by Oliver Maor-->
 			</th>
 		</tr>
 		<tr class="alternate">
@@ -336,6 +355,15 @@ $spam_master_integrations_woocommerce = get_option('spam_master_integrations_woo
 				<p>Color Scheme options are: <b>light</b> or <b>dark</b>.</p>
 			</td>
 		</tr>
+		<!-- Code added by Oliver Maor-->
+				<tr class="alternate">
+			<td>
+				<input name="spam_master_recaptcha_ampoff" id="spam_master_recaptcha_ampoff" value="true" type="checkbox" <?php if(is_multisite()){echo get_blog_option($blog_id, 'spam_master_recaptcha_ampoff') == 'true' ? 'checked="checked"':'';}else{echo get_option('spam_master_recaptcha_ampoff') == 'true' ? 'checked="checked"':'';} ?> />
+				<label for="spam_master_recaptcha_ampoff"><b><?php _e('Switch off Re-Captcha on AMP pages', 'spam_master'); ?></b></label>
+			</td>
+			<td></td>
+		</tr>
+		<!-- End code added by Oliver Maor-->
 		<tr class="alternate">
 			<td>
 				<input name="spam_master_recaptcha_preview" id="spam_master_recaptcha_preview" value="true" type="checkbox" <?php if(is_multisite()){echo get_blog_option($blog_id, 'spam_master_recaptcha_preview') == 'true' ? 'checked="checked"':'';}else{echo get_option('spam_master_recaptcha_preview') == 'true' ? 'checked="checked"':'';} ?> />
@@ -349,6 +377,9 @@ $spam_master_integrations_woocommerce = get_option('spam_master_integrations_woo
 if(is_multisite()){
 $spam_master_recaptcha_version = get_blog_option($blog_id, 'spam_master_recaptcha_version');
 $spam_master_recaptcha_preview = get_blog_option($blog_id, 'spam_master_recaptcha_preview');
+/* Code added by Oliver Maor */
+$spam_master_recaptcha_preview = get_blog_option($blog_id, 'spam_master_recaptcha_ampoff');
+/* End code added by Oliver Maor */
 $spam_master_recaptcha_public_key = get_blog_option($blog_id, 'spam_master_recaptcha_public_key');
 $spam_master_recaptcha_secret_key = get_option('spam_master_recaptcha_secret_key');
 $spam_master_recaptcha_theme = get_blog_option($blog_id,'spam_master_recaptcha_theme');
@@ -356,6 +387,9 @@ $spam_master_recaptcha_theme = get_blog_option($blog_id,'spam_master_recaptcha_t
 else{
 $spam_master_recaptcha_version = get_option('spam_master_recaptcha_version');
 $spam_master_recaptcha_preview = get_option('spam_master_recaptcha_preview');
+/* Code added by Oliver Maor */
+$spam_master_recaptcha_preview = get_option('spam_master_recaptcha_ampoff');
+/* End code added by Oliver Maor */
 $spam_master_recaptcha_public_key = get_option('spam_master_recaptcha_public_key');
 $spam_master_recaptcha_secret_key = get_option('spam_master_recaptcha_secret_key');
 $spam_master_recaptcha_theme = get_option('spam_master_recaptcha_theme');

--- a/includes/protection/spam-master-admin-other-protection.php
+++ b/includes/protection/spam-master-admin-other-protection.php
@@ -1,4 +1,5 @@
 <?php
+/* Contains code added by Oliver Maor. Is somewhat tested, but should be double-checked before final inclusion. */
 function menu_rct_single(){
 	if ( is_admin() )
 	add_submenu_page( 'spam-master', 'Protection Tools', 'Protection Tools', 'manage_options', 'spam-master-recaptcha', 'spam_master_recaptcha' );
@@ -176,6 +177,9 @@ $spam_master_recaptcha_registration = get_blog_option($blog_id, 'spam_master_rec
 $spam_master_recaptcha_login = get_blog_option($blog_id, 'spam_master_recaptcha_login');
 $spam_master_recaptcha_comments = get_blog_option($blog_id, 'spam_master_recaptcha_comments');
 $spam_master_recaptcha_public_key = get_blog_option($blog_id, 'spam_master_recaptcha_public_key');
+/* Code added by Oliver Maor */
+$spam_master_recaptcha_ampoff = get_blog_option($blog_id, 'spam_master_recaptcha_ampoff');
+/* End code added by Oliver Maor */
 $spam_master_honeypot_timetrap = get_blog_option($blog_id, 'spam_master_honeypot_timetrap');
 $spam_master_honeypot_timetrap_speed = get_blog_option($blog_id, 'spam_master_honeypot_timetrap_speed');
 $spam_master_signature_registration = get_blog_option($blog_id, 'spam_master_signature_registration');
@@ -190,6 +194,9 @@ $spam_master_recaptcha_registration = get_option('spam_master_recaptcha_registra
 $spam_master_recaptcha_login = get_option('spam_master_recaptcha_login');
 $spam_master_recaptcha_comments = get_option('spam_master_recaptcha_comments');
 $spam_master_recaptcha_public_key = get_option('spam_master_recaptcha_public_key');
+/* Code added by Oliver Maor */
+$spam_master_recaptcha_ampoff = get_option('spam_master_recaptcha_ampoff');
+/* End code added by Oliver Maor */
 $spam_master_honeypot_timetrap = get_option('spam_master_honeypot_timetrap');
 $spam_master_honeypot_timetrap_speed = get_option('spam_master_honeypot_timetrap_speed');
 $spam_master_signature_registration = get_option('spam_master_signature_registration');
@@ -229,39 +236,57 @@ if(is_multisite()){
 $spam_master_recaptcha_public_key = get_blog_option($blog_id, 'spam_master_recaptcha_public_key');
 $spam_master_recaptcha_secret_key = get_blog_option($blog_id, 'spam_master_recaptcha_secret_key');
 $spam_master_recaptcha_theme = get_blog_option($blog_id, 'spam_master_recaptcha_theme');
+/* Code added by Oliver Maor */
+$spam_master_recaptcha_ampoff = get_blog_option($blog_id, 'spam_master_recaptcha_ampoff');
+/* End code added by Oliver Maor */
 }
 else{
 $spam_master_recaptcha_public_key = get_option('spam_master_recaptcha_public_key');
 $spam_master_recaptcha_secret_key = get_option('spam_master_recaptcha_secret_key');
 $spam_master_recaptcha_theme = get_option('spam_master_recaptcha_theme');
+/* Code added by Oliver Maor */
+$spam_master_recaptcha_ampoff = get_option('spam_master_recaptcha_ampoff');
+/* End code added by Oliver Maor */
 }
-?>
-<label>Re-CAPTCHA Code</label>
-<?php
-echo '<script src="https://www.google.com/recaptcha/api.js"></script>' .
-'<div class="g-recaptcha" data-theme="'.$spam_master_recaptcha_theme.'" data-sitekey="'.$spam_master_recaptcha_public_key.'"></div>';
-if (is_multisite()){
-?>
-<p>Press <b>Next</b> after verifying captcha.</p>
-<br>
-<?php
-}
-else{
-?>
-<p>Press <b>Register</b> after verifying captcha.</p>
-<br>
-<?php
+/* Code added by Oliver Maor */
+if ( !('true' == spam_master_amp_check() && !( 'true' == $spam_master_recaptcha_ampoff ) ) ) {
+/*End code added by Oliver Maor */
+	?>
+	<label>Re-CAPTCHA Code</label>
+	<?php
+	echo '<script src="https://www.google.com/recaptcha/api.js"></script>' .
+	'<div class="g-recaptcha" data-theme="'.$spam_master_recaptcha_theme.'" data-sitekey="'.$spam_master_recaptcha_public_key.'"></div>';
+	if (is_multisite()){
+	?>
+	<p>Press <b>Next</b> after verifying captcha.</p>
+	<br>
+	<?php
+	}
+	else{
+	?>
+	<p>Press <b>Register</b> after verifying captcha.</p>
+	<br>
+	<?php
+	/* Code added by Oliver Maor */
+	}
+/* End code added by Oliver Maor */	
 }
 }
 //END FIELD
 //START ERRORS VALIDATION MULTI SITE
 function spam_master_recaptcha_register_multi_errors($result){
-if(isset($_POST['g-recaptcha-response'])){
-$captcha=$_POST['g-recaptcha-response'];
-	if(!$captcha){
-			$result['errors']->add('invalid_email',__('<strong>SPAM MASTER</strong>: Insert Correct Captcha','spam_master'));
-			echo '<p class="error"><strong>SPAM MASTER</strong>: Insert Correct Captcha</p>';
+/* Code added by Oliver Maor */
+if ( !('true' == spam_master_amp_check() && !( 'true' == $spam_master_recaptcha_ampoff ) ) ) {
+	/* End code added by Oliver Maor */
+	if(isset($_POST['g-recaptcha-response'])){
+	$captcha=$_POST['g-recaptcha-response'];
+		if(!$captcha){
+				$result['errors']->add('invalid_email',__('<strong>SPAM MASTER</strong>: Insert Correct Captcha','spam_master'));
+				echo '<p class="error"><strong>SPAM MASTER</strong>: Insert Correct Captcha</p>';
+		}
+	/* Code added by Oliver Maor */
 	}
+/*End code added by Oliver Maor */
 }
 return $result;
 }
@@ -291,18 +316,24 @@ return $errors;
 //////////////////////////////////////
 if ($spam_master_recaptcha_login == 'true'){
 	if ($spam_master_recaptcha_public_key !== ''){
-		//MULTISITE HOOKS
-		if(is_multisite()){
-		add_action('signup_extra_fields', 'spam_master_recaptcha_login_field' );
-		add_action('login_form', 'spam_master_recaptcha_login_field');
-		add_action('login_head', 'spam_master_recaptcha_login_errors', 99);
+		/* Code added by Oliver Maor */
+		if ( !('true' == spam_master_amp_check() && !( 'true' == $spam_master_recaptcha_ampoff ) ) ) {
+			/*End code added by Oliver Maor */
+			//MULTISITE HOOKS
+			if(is_multisite()){
+				add_action('signup_extra_fields', 'spam_master_recaptcha_login_field' );
+				add_action('login_form', 'spam_master_recaptcha_login_field');
+				add_action('login_head', 'spam_master_recaptcha_login_errors', 99);
+			}
+			//SINGLE SITE HOOKS
+			else{
+				add_action('login_enqueue_scripts', 'spam_master_recaptcha_login_css');
+				add_action('login_form', 'spam_master_recaptcha_login_field');
+				add_filter( 'wp_authenticate_user', 'spam_master_recaptcha_login_errors', 10, 3 );
+			}
+		/*Code added by Oliver Maor */
 		}
-		//SINGLE SITE HOOKS
-		else{
-		add_action('login_enqueue_scripts', 'spam_master_recaptcha_login_css');
-		add_action('login_form', 'spam_master_recaptcha_login_field');
-		add_filter( 'wp_authenticate_user', 'spam_master_recaptcha_login_errors', 10, 3 );
-		}
+		/* End code added by Oliver Maor */
 //CSS FOR SINGLE SITE
 function spam_master_recaptcha_login_css(){
 	echo '<style type="text/css">';
@@ -317,16 +348,28 @@ if(is_multisite()){
 $spam_master_recaptcha_public_key = get_blog_option($blog_id, 'spam_master_recaptcha_public_key');
 $spam_master_recaptcha_secret_key = get_blog_option($blog_id, 'spam_master_recaptcha_secret_key');
 $spam_master_recaptcha_theme = get_blog_option($blog_id, 'spam_master_recaptcha_theme');
+/* Code added by Oliver Maor */
+$spam_master_recaptcha_ampoff = get_blog_option($blog_id, 'spam_master_recaptcha_ampoff');
+/* End code added by Oliver Maor */
 }
 else{
 $spam_master_recaptcha_public_key = get_option('spam_master_recaptcha_public_key');
 $spam_master_recaptcha_secret_key = get_option('spam_master_recaptcha_secret_key');
 $spam_master_recaptcha_theme = get_option('spam_master_recaptcha_theme');
+/* Code added by Oliver Maor */
+$spam_master_recaptcha_ampoff = get_option('spam_master_recaptcha_ampoff');
+/* End code added by Oliver Maor */
 }
-echo '<script src="https://www.google.com/recaptcha/api.js"></script>';
-echo '<label>Re-CAPTCHA Code</label>' .
-	'<div class="g-recaptcha" data-theme="'.$spam_master_recaptcha_theme.'" data-sitekey="' . $spam_master_recaptcha_public_key . '"></div>';
+/* Code added by Oliver Maor */
+if ( !('true' == spam_master_amp_check() && !( 'true' == $spam_master_recaptcha_ampoff ) ) ) {
+/*End code added by Oliver Maor */
+	echo	'<script src="https://www.google.com/recaptcha/api.js"></script>';
+	echo	'<label>Re-CAPTCHA Code</label>' .
+			'<div class="g-recaptcha" data-theme="'.$spam_master_recaptcha_theme.'" data-sitekey="' . $spam_master_recaptcha_public_key . '"></div>';
 //END FIELD
+/* Code added by Oliver Maor */
+}
+/* End code added by Oliver Maor */
 }
 
 //START ERRORS VALIDATION
@@ -336,13 +379,23 @@ if(is_multisite()){
 $spam_master_recaptcha_public_key = get_blog_option($blog_id, 'spam_master_recaptcha_public_key');
 $spam_master_recaptcha_secret_key = get_blog_option($blog_id, 'spam_master_recaptcha_secret_key');
 $spam_master_recaptcha_theme = get_blog_option($blog_id, 'spam_master_recaptcha_theme');
+/* Code added by Oliver Maor */
+$spam_master_recaptcha_ampoff = get_blog_option($blog_id, 'spam_master_recaptcha_ampoff');
+/* End code added by Oliver Maor */
 }
 else{
 $spam_master_recaptcha_public_key = get_option('spam_master_recaptcha_public_key');
 $spam_master_recaptcha_secret_key = get_option('spam_master_recaptcha_secret_key');
 $spam_master_recaptcha_theme = get_option('spam_master_recaptcha_theme');
+/* Code added by Oliver Maor */
+$spam_master_recaptcha_ampoff = get_option('spam_master_recaptcha_ampoff');
+/* End code added by Oliver Maor */
 }
-	if ( isset( $_POST['g-recaptcha-response'] ) ) {
+/* Code added / modified by Oliver Maor */
+if ( !('true' == spam_master_amp_check() && !( 'true' == $spam_master_recaptcha_ampoff ) ) ) {
+	return $user;
+}
+	elseif /* End code added / modified by Oliver Maor */( isset( $_POST['g-recaptcha-response'] ) ) {
 		$response = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=' . $spam_master_recaptcha_secret_key . '&response=' . $_POST['g-recaptcha-response'] );
 		$response = json_decode( $response['body'], true );
 		if ( true === $response['success'] ) {
@@ -394,17 +447,28 @@ if(is_multisite()){
 $spam_master_recaptcha_public_key = get_blog_option($blog_id, 'spam_master_recaptcha_public_key');
 $spam_master_recaptcha_secret_key = get_blog_option($blog_id, 'spam_master_recaptcha_secret_key');
 $spam_master_recaptcha_theme = get_blog_option($blog_id, 'spam_master_recaptcha_theme');
+/* Code added by Oliver Maor */
+$spam_master_recaptcha_ampoff = get_blog_option($blog_id, 'spam_master_recaptcha_ampoff');
+/* End code added by Oliver Maor */
 }
 else{
 $spam_master_recaptcha_public_key = get_option('spam_master_recaptcha_public_key');
 $spam_master_recaptcha_secret_key = get_option('spam_master_recaptcha_secret_key');
 $spam_master_recaptcha_theme = get_option('spam_master_recaptcha_theme');
+/* Code added by Oliver Maor */
+$spam_master_recaptcha_ampoff = get_option('spam_master_recaptcha_ampoff');
+/* End code added by Oliver Maor */
 }
-
-echo '<script src="https://www.google.com/recaptcha/api.js"></script>';
-echo '<p class="comment-form-recaptcha">' .
-		'<label>Re-CAPTCHA Code</label>' .
-		'<div class="g-recaptcha" data-theme="'.$spam_master_recaptcha_theme.'" data-sitekey="' . $spam_master_recaptcha_public_key . '"></div></p>';
+/* Code added by Oliver Maor */
+if ( !('true' == spam_master_amp_check() && !( 'true' == $spam_master_recaptcha_ampoff ) ) ) {
+/*End code added by Oliver Maor */
+	echo	'<script src="https://www.google.com/recaptcha/api.js"></script>';
+	echo	'<p class="comment-form-recaptcha">' .
+			'<label>Re-CAPTCHA Code</label>' .
+			'<div class="g-recaptcha" data-theme="'.$spam_master_recaptcha_theme.'" data-sitekey="' . $spam_master_recaptcha_public_key . '"></div></p>';
+	/*Code added by Oliver Maor */
+	}
+	/*End code added by Oliver Maor */
 }
 //COMMENT VERIFICATION
 function spam_master_verify_comment_data($commentdata){
@@ -413,13 +477,23 @@ if(is_multisite()){
 $spam_master_recaptcha_public_key = get_blog_option($blog_id, 'spam_master_recaptcha_public_key');
 $spam_master_recaptcha_secret_key = get_blog_option($blog_id, 'spam_master_recaptcha_secret_key');
 $spam_master_recaptcha_theme = get_blog_option($blog_id, 'spam_master_recaptcha_theme');
+/* Code added by Oliver Maor */
+$spam_master_recaptcha_ampoff = get_blog_option($blog_id, 'spam_master_recaptcha_ampoff');
+/* End code added by Oliver Maor */
 }
 else{
 $spam_master_recaptcha_public_key = get_option('spam_master_recaptcha_public_key');
 $spam_master_recaptcha_secret_key = get_option('spam_master_recaptcha_secret_key');
 $spam_master_recaptcha_theme = get_option('spam_master_recaptcha_theme');
+/* Code added by Oliver Maor */
+$spam_master_recaptcha_ampoff = get_option('spam_master_recaptcha_ampoff');
+/* End code added by Oliver Maor */
 }
-	if ( isset( $_POST['g-recaptcha-response'] ) ) {
+/* Code added / modified by Oliver Maor */
+	if ( !('true' == spam_master_amp_check() && !( 'true' == $spam_master_recaptcha_ampoff ) ) ) {
+			return $commentdata;
+	}
+	elseif /*End code added / modified by Oliver Maor */ ( isset( $_POST['g-recaptcha-response'] ) ) {
 		$response = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=' . $spam_master_recaptcha_secret_key . '&response=' . $_POST['g-recaptcha-response'] );
 		$response = json_decode( $response['body'], true );
 		if ( true === $response['success'] ) {
@@ -765,3 +839,18 @@ function spam_master_attempt_remove_comment_website_field($fields){
 }
 add_filter('comment_form_default_fields','spam_master_attempt_remove_comment_website_field');
 }
+/* Code added by Oliver Maor */
+/* Function to check whether an AMP page is being retrieved */
+/* Supports two AMP Plugins: "AMP for WP" and "AMP" by Automattic, Inc. */
+function spam_master_amp_check() {
+	if (function_exists( 'ampforwp_is_amp_endpoint' ) && ampforwp_is_amp_endpoint () ) {
+		return 'true';
+	}
+	elseif (function_exists( 'is_amp_endpoint' ) && is_amp_endpoint () ) {
+		return 'true';
+	}
+	else{
+		return 'false';
+	}
+}
+/* End code added by Oliver Maor */

--- a/includes/settings/spam-master-admin-settings-uninstall-options.php
+++ b/includes/settings/spam-master-admin-settings-uninstall-options.php
@@ -84,6 +84,10 @@ $spam_master_cron = "UNINS";
 	delete_blog_option($blog_id, 'spam_master_recaptcha_login');
 	delete_blog_option($blog_id, 'spam_master_recaptcha_comments');
 	delete_blog_option($blog_id, 'spam_master_recaptcha_public_key');
+	/* code added by Oliver Maor - delete "AMP off" setting as well as the preview option (obviously forgotten before) */
+	delete_blog_option($blog_id, 'spam_master_recaptcha_preview');
+	delete_blog_option($blog_id, 'spam_master_recaptcha_ampoff');
+	/* End code added by Oliver Maor */
 	delete_blog_option($blog_id, 'spam_license_key_old_code');
 	update_blog_option($blog_id, 'blacklist_keys_bk', get_blog_option($blog_id, 'blacklist_keys'));
 	delete_blog_option($blog_id, 'blacklist_keys');
@@ -200,6 +204,10 @@ $spam_master_cron = "UNINS";
 	delete_option('spam_master_recaptcha_login');
 	delete_option('spam_master_recaptcha_comments');
 	delete_option('spam_master_recaptcha_public_key');
+	/* code added by Oliver Maor - delete "AMP off" setting as well as the preview option (obviously forgotten before) */
+	delete_option('spam_master_recaptcha_preview');
+	delete_option('spam_master_recaptcha_ampoff');
+	/* End code added by Oliver Maor */
 	delete_option('spam_license_key_old_code');
 	update_option('blacklist_keys_bk', get_option('blacklist_keys'));
 	delete_option('blacklist_keys');


### PR DESCRIPTION
Re-Captcha is not AMP compatible. In some environments and settings, a Re-Captcha would be shown in automatically generated AMP pages anyway. This update allows a setting to toggle off Re-Captcha in AMP pages. It is supposed to work with the AMP plugins "AMP" by Automattic, Inc., and "AMP for WP".